### PR TITLE
Ministep: initialize currentScale array

### DIFF
--- a/src/Ministep.cpp
+++ b/src/Ministep.cpp
@@ -57,7 +57,10 @@ struct Ministep : Module {
 		configOutput(STEP_OUTPUT, "Step");
 
 		nSteps = DEFAULT_NSTEPS;
-		for(int i = 0; i < MAX_POLY_CHANNELS; i++) currentStep[i] = 0;
+		for(int i = 0; i < MAX_POLY_CHANNELS; i++) {
+			currentStep[i] = 0;
+			currentScale[i] = 1;
+		}
 	}
 
 	void onReset() override {


### PR DESCRIPTION
Fixes use of undefined values when module is added while plugin is bypassed.
Detected by valgrind.

```
 ==156814== Conditional jump or move depends on uninitialised value(s)
==156814==    at 0x7948958: __vfprintf_internal (vfprintf-internal.c:1687)
==156814==    by 0x795CF99: __vsnprintf_internal (vsnprintf.c:114)
==156814==    by 0x2875500: vsnprintf (stdio2.h:80)
==156814==    by 0x2875500: rack::string::fV[abi:cxx11](char const*, __va_list_tag*) (string.cpp:33)
==156814==    by 0x287567F: rack::string::f[abi:cxx11](char const*, ...) (string.cpp:21)
==156814==    by 0x203E22E: PolyIntDisplayWidget (Ministep.cpp:197)
==156814==    by 0x203E22E: ScaleDisplayWidget (Ministep.cpp:250)
==156814==    by 0x203E22E: MinistepWidget::MinistepWidget(Ministep*) (Ministep.cpp:400)
```
